### PR TITLE
Make test fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,8 @@ endif
 sample.test$(DOTEXE): $(call test_files_for,sample.test.c)
 	$(CC) $(CFLAGS) -o $@ $^
 
-test: 
-	prove -f -e "" ./sample.test$(DOTEXE)
+test: sample.test$(DOTEXE)
+	prove -f -e "" $(<D)/$(<F)
 
 clean:
 	$(RM) $(TESTICKLE_BUILT_ITEMS)


### PR DESCRIPTION
This uses the $(<D) and $(<F) variables in Make to ensure that the `prove` call works.

Also it ensures that the `test` target relies on `sample.test` being up-to-date.

P.S. I don't know how to get it to ignore all those merge-tracking commits :-/.
